### PR TITLE
Adding work around for deleted invites

### DIFF
--- a/Cogs/member_log.py
+++ b/Cogs/member_log.py
@@ -23,7 +23,7 @@ class MemberLog(commands.Cog):
         account_age = BetterDateTime.utcnow() - BetterDateTime.from_datetime(
             member.created_at
         )
-        invite_used = "Vanity URL"
+        invite_used = "Unknown Invite"
         invite_uses = ""
         inviter = ""
         for invite in await member.guild.invites():

--- a/__init__.py
+++ b/__init__.py
@@ -33,7 +33,7 @@ intents = discord.Intents.default()
 intents.members = True
 
 bot = commands.Bot(
-    command_prefix="bum.",
+    command_prefix="lum.",
     intents=intents,
     activity=discord.Activity(
         type=discord.ActivityType.watching, name="with ten thousand eyes."

--- a/__init__.py
+++ b/__init__.py
@@ -17,6 +17,7 @@ from Helpers.helpers import (
     add_all_invites,
     add_all_guild_invites,
     remove_all_guild_invites,
+    get_invite,
 )
 from Helpers.models import LJMessage
 
@@ -32,7 +33,7 @@ intents = discord.Intents.default()
 intents.members = True
 
 bot = commands.Bot(
-    command_prefix="lum.",
+    command_prefix="bum.",
     intents=intents,
     activity=discord.Activity(
         type=discord.ActivityType.watching, name="with ten thousand eyes."
@@ -73,6 +74,17 @@ async def on_invite_create(invite: discord.Invite):
 
 @bot.event
 async def on_invite_delete(invite: discord.Invite):
+    invite: discord.Invite = get_invite(invite.id)
+    if invite.uses + 1 == invite.max_uses:
+        gd = db.get_log_by_id(invite.guild.id)
+        log = bot.get_channel(gd.join_id)
+        embed = discord.Embed(
+            description=f"Invite Id: {invite.id}\n" f"Created By: {invite.inviter}",
+            color=0x009DFF,
+        )
+        embed.set_author(name="Invite Deleted", icon_url=bot.user.avatar_url)
+        embed.timestamp = datetime.utcnow()
+        db.add_lumberjack_message(await log.send(embed=embed))
     remove_invite(invite)
 
 


### PR DESCRIPTION
Only tracks deleted invites if the max uses of the invite was one less than the current uses before the invite was deleted.